### PR TITLE
Update canvas initialization for high-DPI screens

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,15 @@ import { TransformSystem } from './ecs/systems';
 import { initWebGPU, createRenderPipeline, render } from './renderer/gpu';
 
 async function main() {
-  const canvas = document.querySelector('canvas') as HTMLCanvasElement | null;
-  if (!canvas) throw new Error('Canvas element not found');
+  // Select the canvas by its ID
+  const canvas = document.getElementById('webgpu-canvas') as HTMLCanvasElement | null;
+  if (!canvas) throw new Error('Canvas element with ID "webgpu-canvas" not found');
+
+  // Make the canvas visually sharp on high-DPI displays
+  const devicePixelRatio = window.devicePixelRatio || 1;
+  canvas.width = canvas.clientWidth * devicePixelRatio;
+  canvas.height = canvas.clientHeight * devicePixelRatio;
+
   const gpu = await initWebGPU(canvas);
   if (!gpu) return;
 


### PR DESCRIPTION
## Summary
- update `src/index.ts` to select the `webgpu-canvas` by id
- adjust canvas size based on device pixel ratio for high-DPI displays

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844dd4a0084832189ed8d649055a102