### PR TITLE
Update demo canvas handling

### DIFF
--- a/src/examples/demo.ts
+++ b/src/examples/demo.ts
@@ -4,8 +4,15 @@ import { TransformSystem } from '../ecs/systems';
 import { initWebGPU, createRenderPipeline, render } from '../renderer/gpu';
 
 export async function runDemo() {
-  const canvas = document.querySelector('canvas') as HTMLCanvasElement | null;
-  if (!canvas) throw new Error('Canvas element not found');
+  // Select the canvas by its ID
+  const canvas = document.getElementById('webgpu-canvas') as HTMLCanvasElement | null;
+  if (!canvas) throw new Error('Canvas element with ID "webgpu-canvas" not found');
+
+  // Make the canvas visually sharp on high-DPI displays
+  const devicePixelRatio = window.devicePixelRatio || 1;
+  canvas.width = canvas.clientWidth * devicePixelRatio;
+  canvas.height = canvas.clientHeight * devicePixelRatio;
+
   const gpu = await initWebGPU(canvas);
   if (!gpu) return;
 
@@ -21,7 +28,7 @@ export async function runDemo() {
     const eid = addEntity(world);
     addComponent(world, Transform, eid);
     addComponent(world, Mesh, eid);
-    Transform.position.x[eid] = i * 1.5;
+    Transform.position.x[eid] = (i - 1) * 1.5; // Center the entities
     entities.push(eid);
   }
 


### PR DESCRIPTION
## Summary
- adjust demo to look up the canvas by `webgpu-canvas` ID
- make canvas high-DPI aware
- center demo entities in the scene

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6844dd7ae46883219ab571929c605d57