### PR TITLE
Update README instructions for raytracing demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,21 +25,16 @@ The generated files are placed in the `dist/` directory.
 
 ## Running the Engine
 
-After building, open `index.html` in a WebGPU capable browser. This page
-initializes the engine and runs a simple scene.
-
-## Demonstration
-
-After building the project you can load a small demo that creates and animates
-several entities. Open `demo.html` in a WebGPU enabled browser:
+After running `npm run build` start a simple HTTP server from the project root:
 
 ```bash
-npm run build
-open demo.html # or use your preferred browser
+npx http-server .
+# or
+python -m http.server
 ```
 
-The demo shows multiple entities rotating while being updated by the ECS every
-frame.
+Then open `http://localhost:8080/raytracing.html` in a WebGPU enabled browser.
+You can also visit `scene3d.html` for the rotating cube example.
 
 ## Goals
 


### PR DESCRIPTION
## Summary
- update instructions for running the demo
- remove reference to deprecated `demo.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68459d0710bc83219245804545f5857a